### PR TITLE
make multiple GPUs returned by API in stable order

### DIFF
--- a/pkg/scheduler/routes/gpu_manage.go
+++ b/pkg/scheduler/routes/gpu_manage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -154,6 +155,13 @@ func ListGPUDetails(s *scheduler.Scheduler) httprouter.Handle {
 		for _, gpuDetail := range uuidToGPUDetails {
 			gpuDetails = append(gpuDetails, *gpuDetail)
 		}
+
+		sort.SliceStable(gpuDetails, func(i, j int) bool {
+			return gpuDetails[i].NodeName < gpuDetails[j].NodeName
+		})
+		sort.SliceStable(gpuDetails, func(i, j int) bool {
+			return gpuDetails[i].ID < gpuDetails[j].ID
+		})
 
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(gpuDetails)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

Currently, where there're multiple GPUs across different nodes, the order returned in `/gpus` API is random in every call, we sort it by id + node name to make the list stable.