### PR TITLE
fix: do not add NVIDIA prefix if already existing

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -142,6 +142,9 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*util.DeviceInfo {
 			klog.Error("nvml get name error ret=", ret)
 			panic(0)
 		}
+		if !strings.Contains(Model, "NVIDIA") {
+			Model = fmt.Sprintf("%v-%v", "NVIDIA", Model)
+		}
 
 		registeredmem := int32(memoryTotal / 1024 / 1024)
 		if *plugin.schedulerConfig.DeviceMemoryScaling != 1 {
@@ -171,7 +174,7 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*util.DeviceInfo {
 			Count:   int32(*plugin.schedulerConfig.DeviceSplitCount),
 			Devmem:  registeredmem,
 			Devcore: int32(*plugin.schedulerConfig.DeviceCoreScaling * 100),
-			Type:    fmt.Sprintf("%v-%v", "NVIDIA", Model),
+			Type:    Model,
 			Numa:    numa,
 			Mode:    plugin.operatingMode,
 			Health:  health,


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:
Currently, for every detected NVIDIA card, the name is added a prefix "NVIDIA", which might be redundant, we only add the prefix if it's missing