### PR TITLE
fix(device-plugin): mount vgpu lock path in container to tmpfs in host

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -69,6 +69,8 @@ const (
 	deviceListAsVolumeMountsContainerPathRoot = "/var/run/nvidia-container-devices"
 	NodeLockNvidia                            = "hami.io/mutex.lock"
 	ConfigFilePath                            = "/config/config.json"
+	hostVGPULockPath                          = "/run/lock/vgpu"
+	containerVGPULockPath                     = "/tmp/vgpulock"
 )
 
 var (
@@ -552,8 +554,8 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 
 				os.MkdirAll(cacheFileHostDirectory, 0777)
 				os.Chmod(cacheFileHostDirectory, 0777)
-				os.MkdirAll("/tmp/vgpulock", 0777)
-				os.Chmod("/tmp/vgpulock", 0777)
+				os.MkdirAll(hostVGPULockPath, 0777)
+				os.Chmod(hostVGPULockPath, 0777)
 				response.Mounts = append(response.Mounts,
 					&kubeletdevicepluginv1beta1.Mount{ContainerPath: fmt.Sprintf("%s/vgpu/libvgpu.so", hostHookPath),
 						HostPath: GetLibPath(),
@@ -561,8 +563,8 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 					&kubeletdevicepluginv1beta1.Mount{ContainerPath: fmt.Sprintf("%s/vgpu", hostHookPath),
 						HostPath: cacheFileHostDirectory,
 						ReadOnly: false},
-					&kubeletdevicepluginv1beta1.Mount{ContainerPath: "/tmp/vgpulock",
-						HostPath: "/tmp/vgpulock",
+					&kubeletdevicepluginv1beta1.Mount{ContainerPath: containerVGPULockPath,
+						HostPath: hostVGPULockPath,
 						ReadOnly: false},
 				)
 				found := false


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

The current vgpu lib lock mechanism, by creating/removing lock file in `/tmp/vgpu` is prune to events such as machine reboot, leaving the lock uncleaned up, we change this to be mounted in the Linux tmpfs `/run` to make it cleaned up across machine reboots.