### PR TITLE
fix(device-plugin): do not abort plugin start in case no device is found

### DIFF
--- a/cmd/device-plugin/nvidia/main.go
+++ b/cmd/device-plugin/nvidia/main.go
@@ -328,7 +328,8 @@ func startPlugins(c *cli.Context, flags []cli.Flag, restarting bool) ([]plugin.I
 	}
 
 	if started == 0 {
-		klog.Info("No devices found. Waiting indefinitely.")
+		klog.Info("No devices found. Retrying in 30s...")
+		return plugins, true, nil
 	}
 
 	return plugins, false, nil

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -93,6 +93,7 @@ func NewNVMLResourceManagers(nvmllib nvml.Interface, config *nvidia.DeviceConfig
 			nvml: nvmllib,
 		}
 		r.rescanInterval = 30 * time.Second
+		r.lastRescan = time.Now()
 		rms = append(rms, r)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind bug

**What this PR does / why we need it**:
In https://github.com/beclab/HAMi/pull/13, support for hot plug/unplug is added to device-plugin. 
In rare cases, the nvidia driver loses control of the only GPU and reinitiates it shortly after. If this happens when the device plugin is starting, and before the reinitialization is finished, NVML may report no devices are found, causing device plugin to abort start, thus when the reinitialization finishes, the GPU still will not be reported by the device plugin. We make the case of no devices also eligible to restart device plugin after a delay.