### PR TITLE
fix(scheduler): minimize sharemode update delay

### DIFF
--- a/pkg/scheduler/nodes.go
+++ b/pkg/scheduler/nodes.go
@@ -125,9 +125,9 @@ func (m *nodeManager) UpdateDeviceShareMode(uuid, mode string) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	for _, node := range m.nodes {
-		for _, dev := range node.Devices {
-			if dev.ID == uuid {
-				dev.ShareMode = mode
+		for i := range node.Devices {
+			if node.Devices[i].ID == uuid {
+				node.Devices[i].ShareMode = mode
 				return nil
 			}
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -261,6 +261,13 @@ func (s *Scheduler) RegisterFromNodeAnnotations() {
 					s.rmNodeDevices(val.Name, devhandsk)
 					continue
 				}
+
+				for _, nodedevice := range nodedevices {
+					if err := s.UpdateDeviceShareMode(nodedevice.ID, nodedevice.ShareMode); err != nil {
+						klog.V(5).InfoS("Skipping share mode sync, device not registered yet", "nodeName", val.Name, "deviceID", nodedevice.ID)
+					}
+				}
+
 				if !needUpdate {
 					klog.V(5).InfoS("No update needed for device", "nodeName", val.Name, "deviceVendor", devhandsk)
 					continue


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

After https://github.com/beclab/HAMi/pull/19, the share mode of all devices are managed by app-service, and the update event of node resource is watched by scheduler's node informer, although immediately, but the device update frequency is capped by the update logic, delaying the update of sharemode, we make the share mode update prior to other metadata update.